### PR TITLE
update cf object key from .guid to .GUID

### DIFF
--- a/es-util.sh
+++ b/es-util.sh
@@ -131,7 +131,7 @@ fi
 log "Getting bindings for ${SERVICE_NAME}."
 
 SVC_JSON=$(cf curl \
-  "/v2/spaces/$(cat ~/.cf/config.json | jq -rc .SpaceFields.Guid)/service_instances?return_user_provided_service_instances=true&q=name%3A${SERVICE_NAME}&inline-relations-depth=1")
+  "/v2/spaces/$(cat ~/.cf/config.json | jq -rc .SpaceFields.GUID)/service_instances?return_user_provided_service_instances=true&q=name%3A${SERVICE_NAME}&inline-relations-depth=1")
 
 ACCESS_KEY=$(echo $SVC_JSON | jq -r '.resources[].entity.service_bindings[].entity.credentials.access_key | select(. != null)')
 SECRET_KEY=$(echo $SVC_JSON | jq -r '.resources[].entity.service_bindings[].entity.credentials.secret_key | select(. != null)')

--- a/make-proxy.sh
+++ b/make-proxy.sh
@@ -184,7 +184,7 @@ function get_proxy_env () {
   log "Getting app environment for $SERVICE_APP."
 
   PROXY_STATUS=$(cf curl \
-    "/v2/spaces/$(cat ~/.cf/config.json | jq -r .SpaceFields.Guid)/apps?q=name%3A${SERVICE_APP}&inline-relations-depth=1")
+    "/v2/spaces/$(cat ~/.cf/config.json | jq -r .SpaceFields.GUID)/apps?q=name%3A${SERVICE_APP}&inline-relations-depth=1")
 
   PROXY_ENV=$(jq -er '.resources[].entity.environment_json' <(echo $PROXY_STATUS))
 
@@ -250,9 +250,9 @@ function bind_env_var () {
 
 # GUID of the currently targeted space.
 CF_CONFIG=$(jq -rc . ~/.cf/config.json)
-SPACE_GUID=$(jq -r .SpaceFields.Guid <(echo $CF_CONFIG))
+SPACE_GUID=$(jq -r .SpaceFields.GUID <(echo $CF_CONFIG))
 SPACE_NAME=$(jq -r .SpaceFields.Name <(echo $CF_CONFIG))
-ORG_GUIDE=$(jq -r .OrganizationFields.Guid <(echo $CF_CONFIG))
+ORG_GUIDE=$(jq -r .OrganizationFields.GUID <(echo $CF_CONFIG))
 ORG_NAME=$(jq -r .OrganizationFields.Name <(echo $CF_CONFIG))
 
 # Give the proxy a useful suffix.


### PR DESCRIPTION
Pairing with @harrisj & @yozlet, we noticed that my user's `~/.cf/config.json` had a different object key for the space GUID. This PR updates a [few](https://github.com/18F/cf-service-proxy/blob/master/make-proxy.sh#L186-L187) [spots](https://github.com/18F/cf-service-proxy/blob/master/es-util.sh#L133-L134) that are currently using the old lowercase key (`.guid`).

This could be due to an update with the cf command line utils but not sure, I'm currently using:
`cf version 6.18.1+a1103f0-2016-05-24`

Also wanted to note that a future enhancement would be to no longer look in the user's `~/.cf/config.json` as the space's GUID is also set in

 `cf env <app_name>`

under `VCAP_APPLICATION.space_id`
